### PR TITLE
Add LLM concurrency, model selection, extractor caching, and preserve original input lines; add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Classification:
   --classify-llm        Force LLM (auto if OPENROUTER_API_KEY set)
   --no-llm              Force heuristic (fast, offline)
   --quality-prompt-file Custom prompt for LLM
+  --llm-concurrency <n> Max concurrent LLM requests (default: 4)
   -s, --samples <n>     Samples per cluster (default: 10)
 
 Clustering:
@@ -57,6 +58,7 @@ Other:
 
 ```bash
 OPENROUTER_API_KEY=...   # Enables LLM classification automatically
+CURARE_EMBED_MODEL=...   # Optional embeddings model (default: Xenova/all-MiniLM-L6-v2)
 ```
 
 ## Background

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ interface CLIOptions {
   model?: string;
   promptFile?: string;
   verbose: boolean;
+  llmConcurrency: number;
 }
 
 function parseArgs(argv: string[]): CLIOptions {
@@ -33,6 +34,7 @@ function parseArgs(argv: string[]): CLIOptions {
     outDir: 'curare-out',  // Default to multi-file output
     samples: 10,  // Better for typicality sampling
     verbose: false,
+    llmConcurrency: 4,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -52,6 +54,8 @@ function parseArgs(argv: string[]): CLIOptions {
       opts.model = args[++i];
     } else if (a === '--quality-prompt-file') {
       opts.promptFile = args[++i];
+    } else if (a === '--llm-concurrency') {
+      opts.llmConcurrency = Math.max(1, parseInt(args[++i], 10) || 1);
     } else if (a === '-s' || a === '--samples') {
       opts.samples = parseInt(args[++i], 10);
     } else if (a === '-v' || a === '--verbose') {
@@ -83,7 +87,7 @@ Examples:
   curare ./texts/ -d out/               # Cluster folder of .md/.txt files
 
 Input:
-  <input>               JSONL file, folder of .md/.txt files, or image folder
+  <input>               JSONL file or folder of .md/.txt files
                         Auto-detects: Alpaca, ShareGPT, OAI, Splice, raw text
 
 Output (default: curare-out/):
@@ -95,6 +99,7 @@ Classification:
   --no-llm              Force heuristic classification (fast, offline)
   --model <name>        OpenRouter model (default: google/gemini-3-flash-preview)
   --quality-prompt-file <path>  Custom prompt from file
+  --llm-concurrency <n> Max concurrent LLM calls (default: 4)
   -s, --samples <n>     Samples per cluster (default: 10)
 
 Clustering:
@@ -146,12 +151,14 @@ async function main() {
 
   // Initialize cache
   const { EmbeddingCache } = await import('./io/cache.js');
-  const cache = new EmbeddingCache();
+  const embedModel = process.env.CURARE_EMBED_MODEL ?? 'Xenova/all-MiniLM-L6-v2';
+  const cache = new EmbeddingCache('.curare', embedModel);
   await cache.load();
 
   // Embed
   log('Computing embeddings...');
   const embeddings = await getTextEmbeddings(items, {
+    model: embedModel,
     cache,
     onProgress: opts.verbose 
       ? (n, t, c) => process.stderr.write(`\rEmbedding ${n}/${t} (${c} cached)`)
@@ -200,14 +207,14 @@ async function main() {
       tag: classification.tag,
       rating: classification.rating,
       items: indices.map(i => items[i].id),
-      samples: samples.slice(0, 3),
+      samples,
     };
   };
 
-  // Parallel classification for LLM, sequential for heuristic (already fast)
+  // Throttle LLM classification requests; heuristic stays sequential and fast.
   const results = useLlm
-    ? await Promise.all(clusterEntries.map(classifyOne))
-    : await Promise.all(clusterEntries.map(classifyOne));
+    ? await mapWithConcurrency(clusterEntries, opts.llmConcurrency, classifyOne)
+    : await mapWithConcurrency(clusterEntries, 1, classifyOne);
 
   // Output
   const sortedResults = results.sort((a, b) => b.size - a.size);
@@ -227,10 +234,11 @@ async function main() {
     // Collect items by rating - preserve original format when available
     const highItems: string[] = [];
     const lowItems: string[] = [];
+    const itemById = new Map(items.map(item => [item.id, item]));
     
     for (const cluster of sortedResults) {
       const clusterItems = cluster.items.map(id => {
-        const item = items.find(i => i.id === id);
+        const item = itemById.get(id);
         if (!item) return null;
         // Use original line if available (preserves OAI format), else normalized
         return item.originalLine ?? JSON.stringify({ id: item.id, text: item.text });
@@ -257,7 +265,7 @@ async function main() {
       for (const cluster of sortedResults) {
         const targetDir = cluster.rating === 'high' ? highDir : lowDir;
         for (const id of cluster.items) {
-          const item = items.find(i => i.id === id);
+          const item = itemById.get(id);
           if (item) {
             await fs.writeFile(path.join(targetDir, item.id), item.text);
             if (cluster.rating === 'high') highCount++; else lowCount++;
@@ -284,6 +292,26 @@ async function main() {
     await fs.writeFile(opts.out, JSON.stringify(output, null, 2));
     console.log(`Wrote ${results.length} clusters to ${opts.out}`);
   }
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      results[index] = await mapper(items[index]);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
 }
 
 main().catch(err => {

--- a/src/embed/text.ts
+++ b/src/embed/text.ts
@@ -5,7 +5,7 @@
 import { pipeline } from '@xenova/transformers';
 import { EmbeddingCache } from '../io/cache.js';
 
-let extractor: any = null;
+const extractors = new Map<string, any>();
 
 const DEFAULT_MODEL = 'Xenova/all-MiniLM-L6-v2';
 
@@ -29,9 +29,11 @@ export async function getTextEmbeddings(
 ): Promise<number[][]> {
   const model = options.model ?? DEFAULT_MODEL;
   const cache = options.cache;
-  
+
+  let extractor = extractors.get(model);
   if (!extractor) {
     extractor = await pipeline('feature-extraction', model);
+    extractors.set(model, extractor);
   }
 
   const results: number[][] = [];

--- a/src/io/builtin.ts
+++ b/src/io/builtin.ts
@@ -24,7 +24,7 @@ registerAdapter({
       try {
         const obj = JSON.parse(line);
         const text = [obj.instruction, obj.input, obj.output].filter(Boolean).join('\n\n');
-        yield { id: obj.id ?? String(idx++), text };
+        yield { id: obj.id ?? String(idx++), text, originalLine: line };
       } catch { /* skip */ }
     }
   }
@@ -48,7 +48,7 @@ registerAdapter({
       try {
         const obj = JSON.parse(line);
         const text = obj.conversations.map((c: { value: string }) => c.value).join('\n\n');
-        yield { id: obj.id ?? String(idx++), text };
+        yield { id: obj.id ?? String(idx++), text, originalLine: line };
       } catch { /* skip */ }
     }
   }
@@ -104,7 +104,7 @@ registerAdapter({
       try {
         const obj = JSON.parse(line);
         if (obj.text) {
-          yield { id: obj.id ?? String(idx++), text: obj.text };
+          yield { id: obj.id ?? String(idx++), text: obj.text, originalLine: line };
         }
       } catch { /* skip */ }
     }

--- a/src/io/cache.ts
+++ b/src/io/cache.ts
@@ -23,7 +23,7 @@ export class EmbeddingCache {
   private data: CacheEntry | null = null;
   private dirty = false;
 
-  constructor(cacheDir = DEFAULT_CACHE_DIR, model = 'all-MiniLM-L6-v2') {
+  constructor(cacheDir = DEFAULT_CACHE_DIR, model = 'Xenova/all-MiniLM-L6-v2') {
     this.cacheDir = cacheDir;
     this.model = model;
   }

--- a/test/adapters.test.ts
+++ b/test/adapters.test.ts
@@ -25,6 +25,7 @@ describe('input adapters', () => {
     expect(adapter).toBe('text-jsonl');
     expect(items).toHaveLength(2);
     expect(items[0].text).toBe('hello');
+    expect(items[0].originalLine).toBe('{"id":"1","text":"hello"}');
   });
 
   it('detects alpaca format', async () => {
@@ -36,6 +37,19 @@ describe('input adapters', () => {
     expect(adapter).toBe('alpaca');
     expect(items[0].text).toContain('Do X');
     expect(items[0].text).toContain('result Z');
+    expect(items[0].originalLine).toBe('{"instruction":"Do X","input":"with Y","output":"result Z"}');
+  });
+
+  it('preserves original line for ShareGPT format', async () => {
+    const file = path.join(tempDir, 'sharegpt.jsonl');
+    const line = '{"id":"c1","conversations":[{"from":"human","value":"hi"},{"from":"gpt","value":"hello"}]}';
+    await fs.writeFile(file, `${line}\n`);
+
+    const { adapter, items } = await autoLoad(file);
+
+    expect(adapter).toBe('sharegpt');
+    expect(items).toHaveLength(1);
+    expect(items[0].originalLine).toBe(line);
   });
 
   it('detects folder format', async () => {

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -79,4 +79,14 @@ describe('EmbeddingCache', () => {
     
     expect(cache.get('any', 'any')).toBeUndefined();
   });
+
+  it('uses Xenova default model name in cache file path', async () => {
+    const cache = new EmbeddingCache(tempDir);
+    await cache.load();
+    cache.set('id1', 'text', [1, 2, 3]);
+    await cache.save();
+
+    const files = await fs.readdir(tempDir);
+    expect(files).toContain('embeddings-Xenova_all-MiniLM-L6-v2.json');
+  });
 });

--- a/test/embed.test.ts
+++ b/test/embed.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Curare — Tests for embedding module behavior
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const pipelineMock = vi.fn();
+vi.mock('@xenova/transformers', () => ({
+  pipeline: pipelineMock,
+}));
+
+describe('getTextEmbeddings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reuses extractor per model and initializes a new one for a different model', async () => {
+    vi.resetModules();
+
+    const extractorByModel = new Map<string, ReturnType<typeof vi.fn>>();
+    pipelineMock.mockImplementation(async (_task: string, model: string) => {
+      if (!extractorByModel.has(model)) {
+        extractorByModel.set(
+          model,
+          vi.fn(async (text: string) => ({
+            data: Float32Array.from([model.length, text.length]),
+          }))
+        );
+      }
+      return extractorByModel.get(model);
+    });
+
+    const { getTextEmbeddings } = await import('../src/embed/text.js');
+
+    await getTextEmbeddings([{ id: '1', text: 'hello' }], { model: 'model/a' });
+    await getTextEmbeddings([{ id: '2', text: 'world' }], { model: 'model/a' });
+    await getTextEmbeddings([{ id: '3', text: 'again' }], { model: 'model/b' });
+
+    expect(pipelineMock).toHaveBeenCalledTimes(2);
+    expect(pipelineMock).toHaveBeenNthCalledWith(1, 'feature-extraction', 'model/a');
+    expect(pipelineMock).toHaveBeenNthCalledWith(2, 'feature-extraction', 'model/b');
+
+    expect(extractorByModel.get('model/a')).toHaveBeenCalledTimes(2);
+    expect(extractorByModel.get('model/b')).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Enable controlled parallelism for LLM classification and support selecting different embedding models via env/CLI to improve performance and flexibility.
- Avoid re-initializing heavy transformers extractors across calls and ensure embedding cache files are keyed by model name.
- Preserve original input lines for JSONL adapters so outputs can retain exact original formatting.

### Description
- Added `--llm-concurrency <n>` CLI flag and `llmConcurrency` option and throttled cluster classification with a new `mapWithConcurrency` helper to bound concurrent LLM calls.
- Introduced `CURARE_EMBED_MODEL` env var and threaded the chosen model into `getTextEmbeddings` and `EmbeddingCache` so the cache filename and extractor are model-aware.
- Implemented per-model extractor caching in `src/embed/text.ts` to reuse initialized `pipeline` instances instead of recreating them.
- Preserved `originalLine` on JSONL adapters (`alpaca`, `sharegpt`, `oai`, `text-jsonl`) and optimized lookups with an `itemById` map when writing outputs; also output full `samples` instead of truncating to 3.
- Updated `README.md` to document `--llm-concurrency` and `CURARE_EMBED_MODEL` and adjusted help text to reflect supported input types.
- Added/updated unit tests: `test/embed.test.ts` to validate extractor reuse, updated `test/adapters.test.ts` to assert `originalLine` preservation, and extended `test/cache.test.ts` to assert cache filename includes the Xenova model name.

### Testing
- Ran unit tests with Vitest covering adapters, cache, and embed modules (`test/adapters.test.ts`, `test/cache.test.ts`, `test/embed.test.ts`).
- All tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2c091b41083278631763f36bdcb74)